### PR TITLE
HttpClient now repeats keyword arguments on redirect uncritically

### DIFF
--- a/questions_three/http_client/http_client.py
+++ b/questions_three/http_client/http_client.py
@@ -104,20 +104,20 @@ class HttpClient:
         return timeout
 
     def _request(
-            self, method, url, *args, data=None, headers={},
+            self, method, url, *args, headers={},
             redirect_depth=0, **kwargs):
         self._check_request_kwargs(kwargs)
         headers = dict(self._persistent_headers, **headers)
         self._transcript.add_request(
-            method, url, data=data, headers=headers, **kwargs)
+            method, url, headers=headers, **kwargs)
         self._logger.debug('%s %s' % (method.upper(), url))
         if self._session is None:
             func = self._send_plain_request
         else:
             func = self._send_session_request
         resp = func(
-            method, url, *args, data=data, headers=headers,
-            verify=self._verify_certs, **kwargs)
+            method, url, *args, headers=headers, verify=self._verify_certs,
+            **kwargs)
         self._logger.debug('HTTP %d\n%s' % (resp.status_code, resp.text))
         self._transcript.add_response(resp)
         if resp.status_code in HANDLE_THESE_REDIRECT_STATUS_CODES:
@@ -129,7 +129,7 @@ class HttpClient:
                 construct_redirect_url(
                     request_url=url,
                     response_location_header=extract_location_header(resp)),
-                headers=headers, data=data, redirect_depth=redirect_depth+1)
+                headers=headers, redirect_depth=redirect_depth+1, **kwargs)
         inspect_response(resp)
         return resp
 

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ from unittest.runner import TextTestRunner
 MAJOR_VERSION = 2
 # An even MINOR_VERSION number indicates a public release
 MINOR_VERSION = 6
-PATCH_VERSION = 0
+PATCH_VERSION = 1
 
 
 class Tester(test):

--- a/tests/http_client/redirection/test_redirection.py
+++ b/tests/http_client/redirection/test_redirection.py
@@ -75,6 +75,16 @@ class TestRedirection(TestCase):
         expect(self.spies.get.kwargs_from_last_call()).to(
             have_keys(data=data))
 
+    def test_repeats_arbitrary_keyword_arguments(self):
+        planted = {
+            'slogan': 'Nobody rejects the Spinach Imposition!',
+            'weapons': ['surprise', 'fear', 'ruthless efficiency']}
+        self.queue_response(status_code=301, location='http://ratses')
+        self.queue_response(status_code=200)
+        HttpClient().get('something', **planted)
+        expect(self.spies.get.kwargs_from_last_call()).to(
+            have_keys(**planted))
+
     def check_follows_absolute_location(self, status_code):
         location = 'https://somewhere.else/spam?eggs#sausage'
         self.queue_response(status_code=status_code, location=location)


### PR DESCRIPTION
This is the public version of the fix for AD-7169.